### PR TITLE
Fix errors on upload to addons.mozilla.org

### DIFF
--- a/src/sieve@mozdev.org/common/libSieve/SieveGui.js
+++ b/src/sieve@mozdev.org/common/libSieve/SieveGui.js
@@ -78,7 +78,7 @@
     $("#DebugStringify")
         .click(function() { $('#txtOutput').val(getSieveScript()); });
     $("#DebugRequire")
-        .click(function() { require(); });
+        .click(function() { require_(); });
     $("#DebugCompact")
         .click(function() { compact(); });
     $("#DebugCapabilities")
@@ -132,7 +132,7 @@
     return dom2.script();
   }
   
-  function require()
+  function require_()
   {
     var requires = {};
     

--- a/src/sieve@mozdev.org/common/libSieve/SieveSimpleGui.html
+++ b/src/sieve@mozdev.org/common/libSieve/SieveSimpleGui.html
@@ -76,7 +76,7 @@ function getSieveScript()
   return dom2.script();
 }
 
-function require()
+function require_()
 {
   var requires = {};
   
@@ -168,7 +168,7 @@ function debug(obj)
     <button onclick="$('#txtOutput').val(getSieveScript());">
 	  Update Sieve Script
 	</button>
-    <button onclick="require()">
+    <button onclick="require_()">
 	  Collect Require
 	</button>	
     <button onclick="capabilities()">

--- a/src/sieve@mozdev.org/install.rdf
+++ b/src/sieve@mozdev.org/install.rdf
@@ -22,8 +22,8 @@
       <!-- Thunderbird -->
       <Description>
         <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
-        <em:minVersion>10</em:minVersion>
-      	<em:maxVersion>70.0</em:maxVersion>  
+        <em:minVersion>10.*</em:minVersion>
+        <em:maxVersion>58.0</em:maxVersion>
       </Description>
     </em:targetApplication>
 


### PR DESCRIPTION
minVersion and maxVersion were invalid according to the addon validator.
Two functions named require crashed the addon validators javascript checker and therefore led to a validation error.

![image](https://user-images.githubusercontent.com/9250103/31516719-cd0e5b32-af99-11e7-8af4-d34364ceb559.png)

Will you now be able to release a up to date version on addons.mozilla.org?