### PR TITLE
SieveAddressParts.js: use :localpart instead of :local

### DIFF
--- a/src/common/libSieve/RFC5228/logic/SieveAddressParts.js
+++ b/src/common/libSieve/RFC5228/logic/SieveAddressParts.js
@@ -36,7 +36,7 @@
 
   SieveLocalPart.isElement
     = function (parser, lexer) {
-      if (parser.startsWith(":local"))
+      if (parser.startsWith(":localpart"))
         return true;
 
       return false;
@@ -44,13 +44,13 @@
 
   SieveLocalPart.prototype.init
     = function (parser) {
-      parser.extract(":local");
+      parser.extract(":localpart");
       return this;
     };
 
   SieveLocalPart.prototype.toScript
     = function () {
-      return ":local";
+      return ":localpart";
     };
 
 

--- a/src/common/libSieve/RFC5228/widgets/SieveAddressPartUI.js
+++ b/src/common/libSieve/RFC5228/widgets/SieveAddressPartUI.js
@@ -169,7 +169,7 @@
     = function (callback) {
 
       return SieveAbstractAddressPartUI.prototype.html.call(
-        this, ":local", "... a local part with...",
+        this, ":localpart", "... a local part with...",
         'Everything before the @ sign. The local part is case sensitive.<br>'
         + 'e.g.: "me@example.com" is stripped to "me"', callback);
     };


### PR DESCRIPTION
According to RFC 5228, `:localpart` is a valid optional argument for address comparison but `:local` is not.