### PR TITLE
Update locale.properties

### DIFF
--- a/src/addon/chrome/chromeFiles/locale/hu_HU/locale.properties
+++ b/src/addon/chrome/chromeFiles/locale/hu_HU/locale.properties
@@ -37,9 +37,9 @@ account.auth.custom=Egyéni bejelentkezés használata
 
 # Menu entries
 menu.filters=Szita üzenetszűrők…
-menu.filters.key=M
+menu.filters.key=ü
 menu.options=Szita szűrő beállítások…
-menu.options.key=S
+menu.options.key=ű
 
 # Save Script Prompt
 edit.save.title=Szita parancsfájlt mentése
@@ -52,8 +52,8 @@ account.authorization.description=Adja meg a felhasználónevét
 # Password Prompt
 account.password.title=Jelszó
 account.password.description=Adja meg a Szita fiók jelszavát
-account.password.username=Felhasználónév\:
-account.password.hostname=Gépnév\:
+account.password.username=Felhasználónév:
+account.password.hostname=Gépnév:
 account.password.remember=Jelszó megjegyzése
 
 # Delete prompt


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Tutorial/Accesskey_display_rules#Don't_include_accesskey_text_in_labels
<command-name>.label=Cancel
<command-name>.accesskey=C

For example:
```
# Menu entries
menu.filters=Szita üzenetszűrők…
menu.filters.key=ü
menu.options=Szita szűrő beállítások…
menu.options.key=ű
```

should be:
```
menu.filters.label=Szita üzenetszűrők…
menu.filters.accesskey=ü
menu.options.label=Szita szűrő beállítások…
menu.options.accesskey=ű
```

`.label` adds properties to the method
`.key` is unable to distinguish between `.accessKey` and `.commandkey`

Other ideas for names can be found at https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/Tutorial/Localization and https://transvision.mozfr.org/

What do you think?

Thank you