### PR TITLE
fix linux import dir (closes #179)

### DIFF
--- a/src/app/libs/managesieve.ui/importer/SieveThunderbirdImport.js
+++ b/src/app/libs/managesieve.ui/importer/SieveThunderbirdImport.js
@@ -113,7 +113,7 @@
       let directory;
 
       if (process.platform === "linux")
-        directory = "~/.thunderbird";
+        directory = path.join(process.env.HOME, ".thunderbird");
       else if (process.platform === "win32")
         directory = path.join(process.env.APPDATA, "Thunderbird");
       else


### PR DESCRIPTION
This fixes #179 by using the HOME environment variable for the Thunderbird import path on linux.