### PR TITLE
add a mac os build option

### DIFF
--- a/gulp/gulpfile.app.js
+++ b/gulp/gulpfile.app.js
@@ -174,6 +174,32 @@ async function packageLinux() {
 }
 
 /**
+ * Packages the build directory and electron for linux
+ * @returns {undefined}
+ */
+async function packageMacOS() {
+  "use strict";
+
+  const options = {
+    dir: BUILD_DIR_APP,
+    arch: "x64",
+    platform: "mas",
+    download: {
+      cache: path.join(common.BASE_DIR_BUILD, "/electron/cache")
+    },
+    out: path.join(common.BASE_DIR_BUILD, "/electron/out"),
+    overwrite: true,
+    // packageManager : "yarn"
+    // packageManager : false,
+    prune: true
+    //app-bundle-id: "com.thsmi.sieve"
+  };
+
+  const packager = require('electron-packager');
+  await packager(options);
+}
+
+/**
  * Updates the addon's version.
  * @returns {undefined}
  */
@@ -222,6 +248,7 @@ exports["packageCommon"] = packageCommon;
 
 exports["packageWin32"] = packageWin32;
 exports["packageLinux"] = packageLinux;
+exports["packageMacOS"] = packageMacOS;
 
 exports['package'] = parallel(
   packageDefinition,

--- a/gulp/gulpfile.app.js
+++ b/gulp/gulpfile.app.js
@@ -174,7 +174,7 @@ async function packageLinux() {
 }
 
 /**
- * Packages the build directory and electron for linux
+ * Packages the build directory and electron for macOS
  * @returns {undefined}
  */
 async function packageMacOS() {
@@ -192,7 +192,7 @@ async function packageMacOS() {
     // packageManager : "yarn"
     // packageManager : false,
     prune: true
-    //app-bundle-id: "com.thsmi.sieve"
+    //app-bundle-id: "net.tschmid.sieve"
   };
 
   const packager = require('electron-packager');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,11 @@ exports['app:package-linux'] = series(
   app.packageLinux
 );
 
+exports['app:package-macos'] = series(
+  app.package,
+  app.packageMacOS
+);
+
 // Addon related gulp tasks
 exports['addon:watch'] = addon.watch;
 exports['addon:package'] = addon.package;


### PR DESCRIPTION
A small change to add the ability to package up a Mac OS app also.  This will let you add a target of 'packageMacOS' and the resulting build can be opened/added to Applications to launch under Mac OS