### PR TITLE
Fix azure build pipeline for macOS

### DIFF
--- a/.azure/macos.yml
+++ b/.azure/macos.yml
@@ -28,19 +28,16 @@ jobs:
   - script: yarn gulp "app:package-macos"
     displayName: "Package macOS Artifacts"
 
-#
-#  FIXME: Zipping the macos binary fails due to invalid symlinks.
-#
-#  - script: yarn gulp "app:zip-macos"
-#    displayName: "Package and Zip macOS Artifacts"
-#
-#  - task: CopyFiles@2
-#    inputs:
-#      Contents: 'build/*.zip'
-#      TargetFolder: '$(build.artifactstagingdirectory)/app'
-#      OverWrite: true
-#
-#  - task: PublishBuildArtifacts@1
-#    inputs:
-#      pathtoPublish: '$(Build.ArtifactStagingDirectory)/app'
-#      artifactName: "Zip - macOS Application"
+  - script: yarn gulp "app:zip-macos"
+    displayName: "Package and Zip macOS Artifacts"
+
+  - task: CopyFiles@2
+    inputs:
+      Contents: 'build/*.zip'
+      TargetFolder: '$(build.artifactstagingdirectory)/app'
+      OverWrite: true
+
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)/app'
+      artifactName: "Zip - macOS Application"


### PR DESCRIPTION
On macOS we have to use zip, because yazl errors out at symbolic links.