### PR TITLE
Fix file modes when creating a zip

### DIFF
--- a/gulp/gulpfile.common.js
+++ b/gulp/gulpfile.common.js
@@ -330,12 +330,12 @@ async function compressDirectory(zip, dir, options) {
 
     let fileOptions = null;
     if (options.permissions) {
+
+      if (options.permissions["*"])
+        fileOptions = { mode: options.permissions["*"] };
+
       if (options.permissions[metaPath])
         fileOptions = { mode: options.permissions[metaPath] };
-
-      if (options.permissions["*"]) {
-        fileOptions = { mode: options.permissions["*"] };
-      }
     }
 
     zip.addFile(realPath, metaPath, fileOptions);


### PR DESCRIPTION
The wildcard file mode needs to be evaluated first.
So that more specific file modes can overwrite it.