### PR TITLE
Detect and use new CertOverride Api

### DIFF
--- a/src/wx/api/sieve/SieveSocketApi.js
+++ b/src/wx/api/sieve/SieveSocketApi.js
@@ -75,6 +75,8 @@
   // eslint-disable-next-line no-magic-numbers
   const LOG_TRACE = (1 << 5);
 
+  const OLD_CERT_API = 5;
+
   /**
    * A simple TCP socket implementation.
    */
@@ -950,8 +952,17 @@
                 cert = certDB.constructX509(cert);
               }
 
-              overrideService.rememberValidityOverride(
-                host, port, cert, flags, false);
+              // The API got changed in Thunderbird 91 it has now six
+              // instead of five arguments.
+              if (overrideService.rememberValidityOverride.length === OLD_CERT_API) {
+                // Five arguments means fallback to the old api
+                overrideService.rememberValidityOverride(
+                  host, port, cert, flags, false);
+              } else {
+                // Not equal to five arguments it is the new api
+                overrideService.rememberValidityOverride(
+                  host, port, {}, cert, flags, false);
+              }
             },
 
             // Event handlers...


### PR DESCRIPTION
Thunderbirds cert API got a breaking change, thus we need to detect the api version and call the rememberValidityOverride() method with the appropiate arguments. #634 