### PR TITLE
Update Open Hub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The project is actively developed. The focus shifted from a thunderbird addon to
 Status and future development plans are described in the [Roadmap](ROADMAP.md). The [Capabilities page](CAPABILITIES.md) contains a list of all supported sieve and manage sieve features.
 
 Project statistics are available at
-[Open Hub](https://www.openhub.net/p/tb-sieve).
+[Open Hub](https://www.openhub.net/p/thsmi-sieve).
 
 A big thank you to everyone who has [contributed and supported](CONTRIBUTORS.md) the project.
 


### PR DESCRIPTION
Because it is now a "It is now a portable standalone application!", I changed from https://www.openhub.net/p/tb-sieve -> https://www.openhub.net/p/thsmi-sieve

I hope it's OK. If not, please let me know, and I will roll back.

Thanks!