### PR TITLE
Fixing support for invalid certificates

### DIFF
--- a/src/app/libs/libManageSieve/SieveClient.mjs
+++ b/src/app/libs/libManageSieve/SieveClient.mjs
@@ -216,6 +216,7 @@ class SieveNodeClient extends SieveAbstractClient {
             fingerprint: cert.fingerprint,
             fingerprint256: cert.fingerprint256,
 
+            code: error.code,
             message: `Error upgrading (${this.tlsSocket.authorizationError})`
           });
 


### PR DESCRIPTION
When user accepts invalid certificate, the error code from the certificate validation is supposed to be stored in host.setIgnoreCertErrors. But the code is not passed to SieveCertValidationException constructor in SieveClients.mjs.

The patch adds the error code to the constructor call.

Fixes https://github.com/thsmi/sieve/issues/892