### PR TITLE
Force space as tab character for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   },
   "files.eol": "\n",
   "editor.tabSize": 2,
+  "editor.insertSpaces": true,
   "editor.useTabStops": false,
   "editor.rulers": [
     80


### PR DESCRIPTION
vscode's indentation detection is not so good. Saves us the trouble of reformatting the code before committing.