### PR TITLE
Support TLS SNI

### DIFF
--- a/src/app/libs/libManageSieve/SieveClient.mjs
+++ b/src/app/libs/libManageSieve/SieveClient.mjs
@@ -136,6 +136,7 @@ class SieveNodeClient extends SieveAbstractClient {
       // this.tlsSocket = tls.TLSSocket(socket, options).connect();
       this.tlsSocket = tls.connect({
         socket: this.socket,
+        servername: this.host,
         rejectUnauthorized: false
       });
 


### PR DESCRIPTION
For people using Pigeonhole on a Dovecot with [local_name certificates](https://doc.dovecot.org/configuration_manual/dovecot_ssl_configuration/#with-client-tls-sni-server-name-indication-support).