### PR TITLE
fix: appimage release url

### DIFF
--- a/.azure/linux.yml
+++ b/.azure/linux.yml
@@ -51,6 +51,9 @@ jobs:
   - script: sudo apt-get install libfuse2
     displayName : "Installing libfuse2"
 
+  - script: sudo apt-get install desktop-file-utils
+    displayName: "Installing desktop-file-utils"
+
   - script: npm run gulp "app:appimage-linux"
     displayName: "Package AppImage Artifact"
 

--- a/gulp/gulpfile.app.mjs
+++ b/gulp/gulpfile.app.mjs
@@ -41,7 +41,7 @@ const LINUX_PLATFORM = "linux";
 const MAC_ARCH = "x64";
 const MAC_PLATFORM = "mas";
 
-const APP_IMAGE_RELEASE_URL = "https://api.github.com/repos/AppImage/AppImageKit/releases";
+const APP_IMAGE_RELEASE_URL = "https://api.github.com/repos/AppImage/appimagetool/releases";
 const APP_IMAGE_TOOL_NAME = "appimagetool-x86_64.AppImage";
 const APP_IMAGE_DIR = path.join(OUTPUT_DIR_APP, "sieve.AppDir");
 


### PR DESCRIPTION
This PR changes the appimage release url to the new non obsolete url. This fixes failing linux builds.