### PR TITLE
Fix hostname/username lookup for Thunderbird 102+

### DIFF
--- a/src/wx/api/sieve/SieveAccountsApi.js
+++ b/src/wx/api/sieve/SieveAccountsApi.js
@@ -61,11 +61,25 @@
             },
 
             async getUsername(id) {
-              return await getIncomingServer(id).realUsername;
+              const server = getIncomingServer(id);
+
+              // realUsername was removed in TB 102 (Bug 1483485),
+              // consolidated into username.
+              if (server.realUsername)
+                return server.realUsername;
+
+              return server.username;
             },
 
             async getHostname(id) {
-              return await getIncomingServer(id).realHostName;
+              const server = getIncomingServer(id);
+
+              // realHostName was removed in TB 102 (Bug 1483485),
+              // consolidated into hostName.
+              if (server.realHostName)
+                return server.realHostName;
+
+              return server.hostName;
             }
           }
         }


### PR DESCRIPTION
## Summary

- `realHostName` and `realUsername` were removed from `nsIMsgIncomingServer` in TB 102 ([Bug 1483485](https://bugzilla.mozilla.org/show_bug.cgi?id=1483485))
- The properties were consolidated into `hostName` and `username`
- This caused the extension to connect to `undefined:4190` on any TB >= 102

Falls back to the new property names when the old ones are unavailable.

## Test plan
- Install extension in TB 128+
- Verify account hostname resolves correctly in the connect flow
- Verify the extension still works on older TB versions (the fallback checks the old property first)