### PR TITLE
Fix AppImage tool download for renamed upstream assets

### DIFF
--- a/gulp/gulpfile.app.mjs
+++ b/gulp/gulpfile.app.mjs
@@ -340,27 +340,27 @@ async function packageAppImage() {
   if (!releases)
     throw new Error("Could not detect latest app image tool version.");
 
-  const latest = releases[0];
-
-  if (!latest)
-    throw new Error("Could not detect latest app image tool version.");
-
   let url = null;
   let tool = null;
 
-  for (const asset of latest.assets) {
-    if (asset.name.toLowerCase() !== APP_IMAGE_TOOL_NAME.toLowerCase())
-      continue;
+  for (const release of releases) {
+    for (const asset of release.assets) {
+      if (asset.name.toLowerCase() !== APP_IMAGE_TOOL_NAME.toLowerCase())
+        continue;
 
-    url = asset.browser_download_url;
-    tool = path.resolve(path.join(
-      CACHE_DIR_APP, `appimagetool-v${latest.tag_name}.AppImage`));
+      url = asset.browser_download_url;
+      tool = path.resolve(path.join(
+        CACHE_DIR_APP, `appimagetool-v${release.tag_name}.AppImage`));
 
-    break;
+      break;
+    }
+
+    if (url && tool)
+      break;
   }
 
   if (!url || !tool)
-    throw new Error("Could not download app image tool.");
+    throw new Error("Could not find appimagetool in any AppImageKit release.");
 
   if (!existsSync(tool))
     await https.download(url, tool);


### PR DESCRIPTION
## Summary

- AppImageKit release 13 renamed all assets with an `obsolete-` prefix (the project is transitioning to [appimagetool](https://github.com/AppImage/appimagetool))
- The build script only checked the latest release, so it couldn't find `appimagetool-x86_64.AppImage`
- Now iterates through all releases until one with the expected asset name is found (falls through to release 12)

This fixes the "App Linux" CI failure.

## Test plan
- [ ] CI "App Linux" check passes