### PR TITLE
Add keyboard shortcuts for search in text editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ delete and add Sieve scripts with a convenient interface? That is exactly what t
 
 … it provides an implementation of [A Protocol for Remotely Managing Sieve Scripts (RFC 5804)](https://wiki.tools.ietf.org/html/rfc5804) as well as a graphical editor for [Sieve: An Email Filtering Language (RFC 5228)](https://tools.ietf.org/html/rfc5228)
 
+## Keyboard Shortcuts
+
+The text editor supports the following keyboard shortcuts:
+
+| Shortcut | Action |
+|---|---|
+| Ctrl+F / Cmd+F | Open search bar and focus search field |
+| F3 | Find next match |
+| Shift+F3 | Find previous match |
+| Enter | Find next match (when search field is focused) |
+| Shift+Enter | Find previous match (when search field is focused) |
+
 
 ## History
 

--- a/src/common/managesieve.ui/editor/text/SieveTextEditor.mjs
+++ b/src/common/managesieve.ui/editor/text/SieveTextEditor.mjs
@@ -170,6 +170,22 @@ class SieveTextEditorUI extends SieveAbstractEditorUI {
       },
       "Shift-Tab": function (cm) {
         cm.indentSelection("subtract");
+      },
+      "Ctrl-F": () => {
+        this.showFindToolbar();
+      },
+      "Cmd-F": () => {
+        this.showFindToolbar();
+      },
+      "F3": () => {
+        const token = document.querySelector("#sieve-editor-txt-find").value;
+        const isCaseSensitive = document.querySelector("#sieve-editor-casesensitive").checked;
+        this.find(token, isCaseSensitive, false);
+      },
+      "Shift-F3": () => {
+        const token = document.querySelector("#sieve-editor-txt-find").value;
+        const isCaseSensitive = document.querySelector("#sieve-editor-casesensitive").checked;
+        this.find(token, isCaseSensitive, true);
       }
     });
 
@@ -230,7 +246,49 @@ class SieveTextEditorUI extends SieveAbstractEditorUI {
         document.querySelector("#sieve-editor-find-toolbar").classList.toggle("d-none");
       });
 
+    document
+      .querySelector("#sieve-editor-txt-find")
+      .addEventListener("keydown", (e) => {
+        if (e.key !== "Enter")
+          return;
+        e.preventDefault();
+        const token = document.querySelector("#sieve-editor-txt-find").value;
+        const isCaseSensitive = document.querySelector("#sieve-editor-casesensitive").checked;
+        this.find(token, isCaseSensitive, e.shiftKey);
+      });
+
+    // Global keyboard shortcuts for search (handles focus outside CodeMirror, e.g. in the search field)
+    document.addEventListener("keydown", (e) => {
+      // Skip if the event originated from within CodeMirror (extraKeys already handled it)
+      if (e.target.closest && e.target.closest(".CodeMirror"))
+        return;
+
+      if ((e.ctrlKey || e.metaKey) && (e.key === "f" || e.key === "F")) {
+        e.preventDefault();
+        this.showFindToolbar();
+        return;
+      }
+
+      if (e.key === "F3") {
+        e.preventDefault();
+        const token = document.querySelector("#sieve-editor-txt-find").value;
+        const isCaseSensitive = document.querySelector("#sieve-editor-casesensitive").checked;
+        this.find(token, isCaseSensitive, e.shiftKey);
+      }
+    });
+
     await this.renderSettings();
+  }
+
+  /**
+   * Shows the find/replace toolbar and focuses the search input.
+   */
+  showFindToolbar() {
+    const toolbar = document.querySelector("#sieve-editor-find-toolbar");
+    toolbar.classList.remove("d-none");
+    const input = document.querySelector("#sieve-editor-txt-find");
+    input.focus();
+    input.select();
   }
 
   /**


### PR DESCRIPTION
- Ctrl+F / Cmd+F: open search toolbar and focus search field
- F3: find next match
- Shift+F3: find previous match
- Enter in search field: find next match
- Shift+Enter in search field: find previous match

Documented in README.md